### PR TITLE
Display old file in compare view for renames

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -300,7 +300,7 @@ export class CommandCenter {
             leftRef = this._model.filesViewContext.leftRef;
             title = `${leftRef} .. ${rightRef}`;
         }
-        commands.executeCommand<void>('vscode.diff', toGitUri(file.uri, leftRef), toGitUri(file.uri, rightRef),
+        commands.executeCommand<void>('vscode.diff', toGitUri(file.oldFileUri, leftRef), toGitUri(file.fileUri, rightRef),
             title + ' | ' + path.basename(file.gitRelativePath), { preview: true });
     }
 


### PR DESCRIPTION
For files with status `Renamed`, the left side of the compare view must
display the old file. To do so, capture the relative name of the old
file along with the actual one in `GitCommittedFile` and use them in the
command `openCommittedFile`.

The URIs of the old and new paths are also needed. Implement these as
computed properties to avoid needlessly calculating and storing the
URIs. They are only used in commands.

Rename `CommittedFile` to `CommittedFileItem` to avoid confusion. It's
not the file itself, but the tree item that represents it.
Instead of implementing the `GitCommittedFile` interface, wrap the file
and provide a reference. This avoids needless copying and results in a
clearer structure.

Also avoid copying from private fields to readonly public fields to
avoid storing two variables instead of one.

Fix #43