### PR TITLE
Fix typo in tooltip about turn on/off Express Mode

### DIFF
--- a/src/historyViewProvider.ts
+++ b/src/historyViewProvider.ts
@@ -98,7 +98,7 @@ export class HistoryViewProvider implements TextDocumentContentProvider {
         this._disposables.push(disposable);
 
         this._expressStatusBar.command = 'githd.setExpressMode';
-        this._expressStatusBar.tooltip = 'Turn on or off of the history vew Express mode';
+        this._expressStatusBar.tooltip = 'Turn on or off of the history view Express mode';
         this.express = this._model.configuration.expressMode;
         this._disposables.push(this._expressStatusBar);
 


### PR DESCRIPTION
Figured out that there is a small typo in the latest version of the extension.
Please Review and approve.