### PR TITLE
Restrict refs to first 100

### DIFF
--- a/src/gitService.ts
+++ b/src/gitService.ts
@@ -188,7 +188,7 @@ export class GitService {
     if (!repo) {
       return [];
     }
-    const result = await this._exec(['for-each-ref', '--format="%(refname) %(objectname:short)"'], repo.root);
+    const result = await this._exec(['for-each-ref', '--format="%(refname) %(objectname:short)"', '--count=100'], repo.root);
     const fn = (line: string): GitRef | null => {
       let match: RegExpExecArray | null;
 


### PR DESCRIPTION
`exec` will cause a buffer overflow if the result is >200kb (it's default maxBuffer). Ideally we'd use spawn instead here, as git should be treated as a subprocess rather than in-process; but there's also efficiency in just limiting the refs to the first 100 instead.

If you prefer, we could swap the `_exec` function to use spawn as below instead:
```ts
private async _exec(args: string[], cwd: string): Promise<string> => {
    const start = Date.now();
    const cmd = gitCommand;
    try {
        const result = await new Promise<string>((resolve, reject) => {
            const childProcess = spawn(cmd, args, { cwd });
            let stdout = '', stderr = '';
            childProcess.stdout.on('data', chunk => { stdout += chunk; });
            childProcess.stderr.on('data', chunk => { stderr += chunk; });
            childProcess
            .on('error', reject)
            .on('close', code => {
                if (code === 0) {
                    resolve(stdout);
                } else {
                    reject(stderr);
                }
            });
        });
        
        Tracer.verbose(`git command: ${cmd}. Output size: ${result.length} (${Date.now() - start}ms) ${cwd}`);
        return result;
    }
    catch (err) {
        Tracer.error(`git command failed: ${cmd} (${Date.now() - start}ms) ${cwd} ${err}`);
        throw err;
    }
}
```