### PR TITLE
fix: prevent input box from closing on focus out

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -94,7 +94,9 @@ async function getRefFromQuickPickItem(
   item: vs.QuickPickItem | EnterShaPickItem,
   inputBoxTitle: string
 ): Promise<string | undefined> {
-  return (<EnterShaPickItem>item).openShaTextBox ? await vs.window.showInputBox({ prompt: inputBoxTitle }) : item.label;
+  return (<EnterShaPickItem>item).openShaTextBox
+    ? await vs.window.showInputBox({ prompt: inputBoxTitle, ignoreFocusOut: true })
+    : item.label;
 }
 
 async function selectAuthor(gitService: GitService, repo: GitRepo): Promise<vs.QuickPickItem[]> {
@@ -300,7 +302,8 @@ export class CommandCenter {
     }
     vs.window
       .showInputBox({
-        placeHolder: `Input a ref(sha1) to see it's committed files`
+        placeHolder: `Input a ref(sha1) to see it's committed files`,
+        ignoreFocusOut: true
       })
       .then(ref => this._model.setFilesViewContext({ rightRef: ref?.trim(), repo }));
   }


### PR DESCRIPTION
## Problem

When using the "View Branch History" feature and selecting "Enter commit SHA", users often need to switch to other windows (e.g., console, browser) to copy SHA values like `commit1..commit2`. However, the VS Code input box disappears immediately when focus is lost, requiring users to start over.

## Solution

Added `ignoreFocusOut: true` option to `showInputBox` calls to keep the input box visible even when VS Code loses focus. This allows users to freely switch between windows to copy SHA values without losing their input.

## Changes

- Modified `getRefFromQuickPickItem()` function to include `ignoreFocusOut: true`
- Modified `inputRef()` command to include `ignoreFocusOut: true`